### PR TITLE
Enable Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ branches:
   only:
     - master
 python:
-  - 3.4
   - 3.5
   - 3.6
   - 3.7
   - 3.8
-  - "pypy"
+  - 3.9
   - "pypy3"
 env:
   global:

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     test_suite='tests',
 )


### PR DESCRIPTION
Hello,

The unit tests seem to be passing on Python 3.9, so it is worth to enable 3.9 on Travis.

Thank you.