### PR TITLE
Fix unit tests on Python 3.10

### DIFF
--- a/datauri/__init__.py
+++ b/datauri/__init__.py
@@ -68,7 +68,7 @@ class DataURI(str):
         return "DataURI(%s)" % (super(DataURI, self).__repr__(),)
 
     def wrap(self, width=76):
-        return "\n".join(textwrap.wrap(self, width))
+        return "\n".join(textwrap.wrap(self, width, break_on_hyphens=False))
 
     @property
     def mimetype(self):


### PR DESCRIPTION
Python 3.10 changed / fixed the `textwrap.wrap()` function's behavior, which we rely on for our `DataURI.wrap()` method. We need to explicitly specify `break_on_hyphens=False` in order to keep the previous behavior.

This PR fixes the following test failure, which occurs in Python 3.10, but not earlier versions:

```
% python -m unittest
....................F
======================================================================
FAIL: test_wrap (tests.test_parsing.ParseTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmp.7DE0oh6201/python-datauri/tests/test_parsing.py", line 111, in test_wrap
    self.assertEqual(
AssertionError: 'data[19 chars]=utf-\n8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW[26 chars]b2cu' != 'data[19 chars]=utf-8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW1w[26 chars]b2cu'
- data:text/plain;charset=utf-
- 8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3ZlciB0aGUgbGF6eSBkb2cu+ data:text/plain;charset=utf-8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3Z
+ lciB0aGUgbGF6eSBkb2cu

----------------------------------------------------------------------
Ran 21 tests in 0.014s

FAILED (failures=1)
```

Applying this PR does not break tests on pre-3.10 versions, as far as I could tell.