### PR TITLE
Exclude tests from wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     description="A li'l class for data URI manipulation in Python",
     long_description=read("README.rst"),
     license="Unlicense",
-    packages=find_packages(exclude=["*.tests"]),
+    packages=find_packages(exclude=["tests", "*.tests"]),
     package_data={
         "faker": ["py.typed"],
     },


### PR DESCRIPTION
Hi there!

Came across this library as a dependency of https://github.com/strictdoc-project/strictdoc. I noticed that the tests for this library are distributed inside the wheel. Unfortunately this breaks test integrations for some users of the library since a number of Python tools detect the `site-packages/tests` directory provided by `python_datauri` in the virtual environment before the local project `tests` directory.

Would you be open to removing the tests from distribution in the wheel? Looks like a pretty simple change to `setup.py`. Happy to help make this happen. If you're willing to publish a new version with this change I will also open a PR with StrictDoc to use the new version.

Without this change the workaround I'm stuck with is to `rm -rf` the `tests` folder in the virtual environment after installation which is less than ideal.

Thanks!