### PR TITLE
fix pydantic json-schema serialization

### DIFF
--- a/datauri/__init__.py
+++ b/datauri/__init__.py
@@ -188,13 +188,16 @@ class DataURI(str):
     def __get_pydantic_json_schema__(
         cls, core_schema: MutableMapping[str, Any], handler: Any
     ) -> Any:
-        core_schema.update(
-            pattern=DATA_URI_REGEX,
-            examples=[
-                "data:text/plain;charset=utf-8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3ZlciB0aGUgbGF6eSBkb2cu"
-            ],
-        )
-        return core_schema
+        json_schema = handler(core_schema)
+        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema['examples'] = [
+            "data:text/plain;charset=utf-8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3ZlciB0aGUgbGF6eSBkb2cu"
+        ]
+        json_schema['pattern'] = DATA_URI_REGEX
+        json_schema['type'] = 'string'
+        json_schema['title'] = 'DataURI'
+
+        return json_schema
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from datauri import DataURI
@@ -37,3 +39,19 @@ def test_pydantic_v2():
         'aGUgbGF6eSBkb2cu"}'
     )
     assert instance.model_dump() == {"content": DataURI(t)}
+
+
+@pytest.mark.skipif(
+    pydantic.__version__.rsplit(".", 3)[0] < "2", reason="pydantic v2 required"
+)
+def test_pydantic_v2_json_schema():
+    class Model(pydantic.BaseModel):
+        content: DataURI
+
+    schema = Model.model_json_schema(schema_generator=pydantic.json_schema.GenerateJsonSchema)
+    schema_json = json.dumps(schema)
+    val = '{"properties": {"content": {"examples": ["data:text/plain;charset=utf-8;base64,VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wZWQgb3ZlciB0aGUgbGF6eSBkb2cu"], "pattern": "data:(?P<mimetype>[\\\w]+\\\/[\\\w\\\-\\\+\\\.]+)?(?:\\\;name\\\=(?P<name>[\\\w\\\.\\\-%!*\'~\\\(\\\)]+))?(?:\\\;charset\\\=(?P<charset>[\\\w\\\-\\\+\\\.]+))?(?P<base64>\\\;base64)?,(?P<data>.*)", "title": "DataURI", "type": "string"}}, "required": ["content"], "title": "Model", "type": "object"}'
+    assert (
+        schema_json
+        == val
+    )


### PR DESCRIPTION
Using `DataURI` as a type in my pydantic model with fastapi, it made the openapi documentation generation crash.

This is because it tried to serialize python `function` and `method` that came from `__get_pydantic_core_schema__`.

I rewrote `__get_pydantic_json_schema__` based on the pydantic doc (https://docs.pydantic.dev/2.10/concepts/json_schema/#implementing-__get_pydantic_json_schema__) so it only contains serializable types.

